### PR TITLE
Adding dashboard module to demo functional test

### DIFF
--- a/cypress/integration/demo_tests/demo_spec.js
+++ b/cypress/integration/demo_tests/demo_spec.js
@@ -24,7 +24,7 @@ describe('opening OpenSearch-Dashboards', () => {
     // Return to the home page before every test, and ensure page has loaded
     beforeEach(() => {
         cy.visit('/app/home').then(() => {
-            cy.get('[data-test-subj="breadcrumb first last"]', { timeout: 20000 }).should('contain', 'Home')
+            cy.get('[data-test-subj="homeApp"]', { timeout: 20000 }).should('be.visible')
         })
     })
 
@@ -59,5 +59,66 @@ describe('opening OpenSearch-Dashboards', () => {
         **/
         cy.get('[data-attr-field="category"]').click()
         cy.get('[data-test-subj="fieldToggle-category"]').click()
+    })
+
+    it('Explore the data in the dashboard', () => {
+        /**
+         * Known issue: Comboboxes UI elements are behaving inconsistently,
+         * can only sometimes successfully "click on" and select options.
+        **/
+        cy.get('[data-test-subj="toggleNavButton"]').click()
+        // Click the Dashboards button in the Nav menu
+        cy.get('[data-test-subj="collapsibleNavAppLink"]').contains('Dashboard').click()
+
+        // Check if automatically opening a dashboard or not
+        cy.url().then((path) => {
+            if (path.includes('/app/dashboards#/list')) {
+                cy.get('[data-test-subj="dashboardListingTitleLink-[eCommerce]-Revenue-Dashboard"]').click()
+            }
+        })
+        // Make sure the desired UI element is visible
+        cy.get('[data-test-subj="inputControl0"]').should('be.visible')
+
+        // Clear all existing filters in the dashboard
+        cy.get('[data-test-subj="showFilterActions"]').click()
+        cy.get('[data-test-subj="removeAllFilters"]').click()
+
+        // Select "Gnomehouse"
+        cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxSearchInput"]').type('{selectall}Gnomehouse')
+        cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
+        cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxInput"]').focus()
+        cy.get('[title="Gnomehouse"]').click({ force: true })
+
+        // Select "Women's Clothing"
+        cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').type("{selectall}Women's Clothing")
+        cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
+        cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').focus()
+        cy.contains('[data-test-subj="listControlSelect1"]', "Women's Clothing").click({ force: true })
+
+        cy.get('[data-test-subj="inputControlSubmitBtn"]').click()
+
+        cy.get('[data-test-subj="addFilter"]').click()
+
+        // Click the "day_of_week" element
+        cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}day_of_week')
+        cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
+        cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').focus()
+        cy.get('[title="day_of_week"]').click({ force: true })
+
+        // Click the "is" operator
+        cy.get('[data-test-subj="filterOperatorList"]').click()
+        cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}is')
+        cy.get('[class="euiFilterSelectItem"]').should('have.length', 6)
+        cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').focus()
+        cy.get('[title="is"]').click({ force: true })
+
+        // Select the "Wednesday" value
+        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').click()
+        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}Wednesday')
+        cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
+        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').focus()
+        cy.get('[title="Wednesday"]').click({ force: true })
+
+        cy.get('[data-test-subj="saveFilter"]').click()
     })
 })


### PR DESCRIPTION
### Description

The existing demo functional test only tests the Discovery page of OpenSearch Dashboards, which does not test the full functionality robustly enough. This PR aims to make the demo more comprehensive by adding a new test suite that focuses on the Dashboard page. It also tweaks the method of checking whether the Home page has fully loaded or not to be more reliable.

The new Dashboard test suite add flakiness to the demo through the testing of the EuiComboBox element, which produces inconsistent behavior when trying to click on an option after entering text in the search box. This will cause the test to sometimes fail due to the combo box entering an "invalid" state and preventing the desired option from being selected. This bug is further discussed in #8.

Signed-off-by: Aviv Benchorin <benchori@amazon.com>

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing. 
    - [x] All tests pass
- [ ] New functionality has been documented. 
    - [ ] New functionality has javadoc added 
- [x] Commits are signed per the DCO using --signoff