### PR TITLE
Add Cypress ESLint Plugin and ESLint README instructions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,26 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true,
-        "node": true
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  extends: [
+    'plugin:react/recommended',
+    'standard'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
     },
-    "extends": [
-        "plugin:react/recommended",
-        "standard"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "indent": ["error", 4]
-    }
-};
+    ecmaVersion: 12,
+    sourceType: 'module'
+  },
+  plugins: [
+    'react',
+    '@typescript-eslint'
+  ],
+  rules: {
+    indent: ['error', 2]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 Functional testing framework to automate OpenSearch Dashboards.
 
 ## Getting Started
-Monterey uses [Cypress](https://www.cypress.io/), which you can install using the [installation guide](https://docs.cypress.io/guides/getting-started/installing-cypress).
+Monterey uses [Cypress](https://www.cypress.io/), which you can install using the [installation guide](https://docs.cypress.io/guides/getting-started/installing-cypress). 
+
+Monterey also uses [ESLint](https://eslint.org/), which you can install using the [installation guide](https://eslint.org/docs/user-guide/getting-started). This project requires you to install the [Cypress ESLint Plugin](https://github.com/cypress-io/eslint-plugin-cypress) for Cypress-specific rules.
 
 ## Running tests
 Before running any tests, make sure that both [OpenSearch](https://github.com/opensearch-project/OpenSearch) and [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards) are running. The demo test expects the OpenSearch Dashboards server base path to be stored as the `baseUrl` variable in the `cypress.json` file (more details [here](https://docs.cypress.io/guides/references/configuration#cypress-json)). By default, the `baseUrl` is set to `http://localhost:5601`.
@@ -14,3 +16,8 @@ To run tests through the Cypress Test Runner, open Cypress using one of the comm
 
 ### CLI
 Given that Cypress was installed as an `npm` module, you can also run Cypress in the command line, as is detailed [here](https://docs.cypress.io/guides/guides/command-line#Installation). To run a specific test, an example command you can use is `npx cypress run --spec "cypress/integration/path/to/test.js"`.
+
+## ESLint
+To run ESLint on the entire project, you can use either `npx eslint .` or `yarn run eslint .`. There are currently two configuration files you can add or modify rules in: `.eslintrc.js` in the root directory for global rules, and `.eslintrc.json` in the `cypress` directory for Cypress-specific rules.
+
+To have ESLint fix issues that it detects and can resolve, you can add the `--fix` flag to the end of the run commands (more details [here](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems)).

--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["plugin:cypress/recommended"]
+}

--- a/cypress/integration/demo_tests/demo_spec.js
+++ b/cypress/integration/demo_tests/demo_spec.js
@@ -4,121 +4,121 @@
 //    to support/index.js to prevent from failing tests with the error.
 
 describe('opening OpenSearch-Dashboards', () => {
-    // Setup the dashboard to start at the home page
-    before(() => {
-        cy.visit('/')
-        cy.request('/api/saved_objects/_find?fields=title&per_page=1&search=*&search_fields=title&type=index-pattern').then((response) => {
-            if (response.body.total === 0) {
-                cy.log('Reached welcome page')
+  // Setup the dashboard to start at the home page
+  before(() => {
+    cy.visit('/')
+    cy.request('/api/saved_objects/_find?fields=title&per_page=1&search=*&search_fields=title&type=index-pattern').then((response) => {
+      if (response.body.total === 0) {
+        cy.log('Reached welcome page')
 
-                // Click the "Add sample data" button
-                cy.get('[class="euiButton euiButton--primary homWelcome__footerAction euiButton--fill"]', { timeout: 15000 }).click()
+        // Click the "Add sample data" button
+        cy.get('[class="euiButton euiButton--primary homWelcome__footerAction euiButton--fill"]', { timeout: 15000 }).click()
 
-                // View the "Sample eCommerce orders" data
-                cy.get('[data-test-subj="addSampleDataSetecommerce"]', { timeout: 15000 }).click()
-                cy.get('[data-test-subj="launchSampleDataSetecommerce"]').should('contain', 'View data')
-            }
-        })
+        // View the "Sample eCommerce orders" data
+        cy.get('[data-test-subj="addSampleDataSetecommerce"]', { timeout: 15000 }).click()
+        cy.get('[data-test-subj="launchSampleDataSetecommerce"]').should('contain', 'View data')
+      }
     })
+  })
 
-    // Return to the home page before every test, and ensure page has loaded
-    beforeEach(() => {
-        cy.visit('/app/home').then(() => {
-            cy.get('[data-test-subj="homeApp"]', { timeout: 20000 }).should('be.visible')
-        })
+  // Return to the home page before every test, and ensure page has loaded
+  beforeEach(() => {
+    cy.visit('/app/home').then(() => {
+      cy.get('[data-test-subj="homeApp"]', { timeout: 20000 }).should('be.visible')
     })
+  })
 
-    it('Exploring data in the Discover page', () => {
-        cy.get('[data-test-subj="toggleNavButton"]').click()
+  it('Exploring data in the Discover page', () => {
+    cy.get('[data-test-subj="toggleNavButton"]').click()
 
-        // Click the Discover button in the Nav menu
-        cy.get('[data-test-subj="collapsibleNavAppLink"]').contains('Discover').click()
+    // Click the Discover button in the Nav menu
+    cy.get('[data-test-subj="collapsibleNavAppLink"]').contains('Discover').click()
 
-        // Ensure that the page is a "blank slate" (clear previous searches, refresh to get rid of old errors)
-        cy.get('[data-test-subj="breadcrumbs"]').should('contain', 'Discover')
-        cy.get('[data-test-subj="queryInput"]').clear()
-        cy.get('[data-test-subj="querySubmitButton"]').click()
+    // Ensure that the page is a "blank slate" (clear previous searches, refresh to get rid of old errors)
+    cy.get('[data-test-subj="breadcrumbs"]').should('contain', 'Discover')
+    cy.get('[data-test-subj="queryInput"]').clear()
+    cy.get('[data-test-subj="querySubmitButton"]').click()
 
-        // Open time quick select tab
-        cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]').click()
+    // Open time quick select tab
+    cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]').click()
 
-        // Select the time range
-        cy.get('[aria-label="Time tense"]').select('Last').should('have.value', 'last')
-        cy.get('[aria-label="Time value"]').clear().type('{selectall}7')
-        cy.get('[aria-label="Time unit"]').select('days').should('have.value', 'd')
-        cy.contains('Apply').click()
+    // Select the time range
+    cy.get('[aria-label="Time tense"]').select('Last').should('have.value', 'last')
+    cy.get('[aria-label="Time value"]').clear().type('{selectall}7')
+    cy.get('[aria-label="Time unit"]').select('days').should('have.value', 'd')
+    cy.contains('Apply').click()
 
-        // Submit a search query
-        cy.get('[data-test-subj="queryInput"]').type("products.taxless_price >= 60 AND category : Women's Clothing")
-        cy.get('[data-test-subj="querySubmitButton"]').click()
+    // Submit a search query
+    cy.get('[data-test-subj="queryInput"]').type("products.taxless_price >= 60 AND category : Women's Clothing")
+    cy.get('[data-test-subj="querySubmitButton"]').click()
 
-        // Select the "category" field
-        /**
-         * Issue: want to be able to "hover" over the category list element,
-         * mouseover/mouseenter did not work (https://docs.cypress.io/api/commands/hover)
-        **/
-        cy.get('[data-attr-field="category"]').click()
-        cy.get('[data-test-subj="fieldToggle-category"]').click()
+    // Select the "category" field
+    /**
+     * Issue: want to be able to "hover" over the category list element,
+     * mouseover/mouseenter did not work (https://docs.cypress.io/api/commands/hover)
+     */
+    cy.get('[data-attr-field="category"]').click()
+    cy.get('[data-test-subj="fieldToggle-category"]').click()
+  })
+
+  it('Explore the data in the dashboard', () => {
+    /**
+     * Known issue: Comboboxes UI elements are behaving inconsistently,
+     * can only sometimes successfully "click on" and select options.
+     */
+    cy.get('[data-test-subj="toggleNavButton"]').click()
+    // Click the Dashboards button in the Nav menu
+    cy.get('[data-test-subj="collapsibleNavAppLink"]').contains('Dashboard').click()
+
+    // Check if automatically opening a dashboard or not
+    cy.url().then((path) => {
+      if (path.includes('/app/dashboards#/list')) {
+        cy.get('[data-test-subj="dashboardListingTitleLink-[eCommerce]-Revenue-Dashboard"]').click()
+      }
     })
+    // Make sure the desired UI element is visible
+    cy.get('[data-test-subj="inputControl0"]').should('be.visible')
 
-    it('Explore the data in the dashboard', () => {
-        /**
-         * Known issue: Comboboxes UI elements are behaving inconsistently,
-         * can only sometimes successfully "click on" and select options.
-        **/
-        cy.get('[data-test-subj="toggleNavButton"]').click()
-        // Click the Dashboards button in the Nav menu
-        cy.get('[data-test-subj="collapsibleNavAppLink"]').contains('Dashboard').click()
+    // Clear all existing filters in the dashboard
+    cy.get('[data-test-subj="showFilterActions"]').click()
+    cy.get('[data-test-subj="removeAllFilters"]').click()
 
-        // Check if automatically opening a dashboard or not
-        cy.url().then((path) => {
-            if (path.includes('/app/dashboards#/list')) {
-                cy.get('[data-test-subj="dashboardListingTitleLink-[eCommerce]-Revenue-Dashboard"]').click()
-            }
-        })
-        // Make sure the desired UI element is visible
-        cy.get('[data-test-subj="inputControl0"]').should('be.visible')
+    // Select "Gnomehouse"
+    cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxSearchInput"]').type('{selectall}Gnomehouse')
+    cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
+    cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxInput"]').focus()
+    cy.get('[title="Gnomehouse"]').click({ force: true })
 
-        // Clear all existing filters in the dashboard
-        cy.get('[data-test-subj="showFilterActions"]').click()
-        cy.get('[data-test-subj="removeAllFilters"]').click()
+    // Select "Women's Clothing"
+    cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').type("{selectall}Women's Clothing")
+    cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
+    cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').focus()
+    cy.contains('[data-test-subj="listControlSelect1"]', "Women's Clothing").click({ force: true })
 
-        // Select "Gnomehouse"
-        cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxSearchInput"]').type('{selectall}Gnomehouse')
-        cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
-        cy.get('[data-test-subj="listControlSelect0"]').find('[data-test-subj="comboBoxInput"]').focus()
-        cy.get('[title="Gnomehouse"]').click({ force: true })
+    cy.get('[data-test-subj="inputControlSubmitBtn"]').click()
 
-        // Select "Women's Clothing"
-        cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').type("{selectall}Women's Clothing")
-        cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
-        cy.get('[data-test-subj="listControlSelect1"]').find('[data-test-subj="comboBoxInput"]').focus()
-        cy.contains('[data-test-subj="listControlSelect1"]', "Women's Clothing").click({ force: true })
+    cy.get('[data-test-subj="addFilter"]').click()
 
-        cy.get('[data-test-subj="inputControlSubmitBtn"]').click()
+    // Click the "day_of_week" element
+    cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}day_of_week')
+    cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
+    cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').focus()
+    cy.get('[title="day_of_week"]').click({ force: true })
 
-        cy.get('[data-test-subj="addFilter"]').click()
+    // Click the "is" operator
+    cy.get('[data-test-subj="filterOperatorList"]').click()
+    cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}is')
+    cy.get('[class="euiFilterSelectItem"]').should('have.length', 6)
+    cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').focus()
+    cy.get('[title="is"]').click({ force: true })
 
-        // Click the "day_of_week" element
-        cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}day_of_week')
-        cy.get('[class="euiFilterSelectItem"]').should('have.length', 2)
-        cy.get('[data-test-subj="filterFieldSuggestionList"]').find('[data-test-subj="comboBoxInput"]').focus()
-        cy.get('[title="day_of_week"]').click({ force: true })
+    // Select the "Wednesday" value
+    cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').click()
+    cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}Wednesday')
+    cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
+    cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').focus()
+    cy.get('[title="Wednesday"]').click({ force: true })
 
-        // Click the "is" operator
-        cy.get('[data-test-subj="filterOperatorList"]').click()
-        cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}is')
-        cy.get('[class="euiFilterSelectItem"]').should('have.length', 6)
-        cy.get('[data-test-subj="filterOperatorList"]').find('[data-test-subj="comboBoxInput"]').focus()
-        cy.get('[title="is"]').click({ force: true })
-
-        // Select the "Wednesday" value
-        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').click()
-        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').type('{selectall}Wednesday')
-        cy.get('[class="euiFilterSelectItem"]').should('have.length', 1)
-        cy.get('[data-test-subj="filterParamsComboBox phraseParamsComboxBox"]').find('[data-test-subj="comboBoxInput"]').focus()
-        cy.get('[title="Wednesday"]').click({ force: true })
-
-        cy.get('[data-test-subj="saveFilter"]').click()
-    })
+    cy.get('[data-test-subj="saveFilter"]').click()
+  })
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,8 +21,8 @@ import './commands'
 
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
 Cypress.on('uncaught:exception', (err) => {
-    /* returning false here prevents Cypress from failing the test */
-    if (resizeObserverLoopErrRe.test(err.message)) {
-        return false
-    }
+  /* returning false here prevents Cypress from failing the test */
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false
+  }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,6 +1045,23 @@
         }
       }
     },
+    "eslint-plugin-cypress": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.3.tgz",
+      "integrity": "sha512-hOoAid+XNFtpvOzZSNWP5LDrQBEJwbZwjib4XJ1KcRYKjeVj0mAmPmucG4Egli4j/aruv+Ow/acacoloWWCl9Q==",
+      "dev": true,
+      "requires": {
+        "globals": "^11.12.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cypress": "^7.6.0",
     "eslint": "^7.30.0",
     "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",


### PR DESCRIPTION
### Description
Currently, the repository has ESLint installed, but has neither set up Cypress-specific rules nor provided instructions on how to use ESLint. This PR adds the Cypress ESLint Plugin to the ESLint configurations to provide, as well as updating the README to include instructions on installing and running ESLint. It also changes the global indentation rule to be 2 spaces instead of 4 and applies the new rules to all files.

Signed-off-by: Aviv Benchorin <benchori@amazon.com>

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing. 
    - [x] All tests pass
- [ ] New functionality has been documented. 
    - [ ] New functionality has javadoc added 
- [x] Commits are signed per the DCO using --signoff